### PR TITLE
fixed error for tutorial page without a video

### DIFF
--- a/app/controllers/admin/tutorials_controller.rb
+++ b/app/controllers/admin/tutorials_controller.rb
@@ -4,6 +4,12 @@ class Admin::TutorialsController < Admin::BaseController
   end
 
   def create
+    new_tutorial = Tutorial.new(tutorial_params)
+    if new_tutorial.save
+      redirect_to admin_dashboard_path
+    else
+      render :new
+    end
   end
 
   def new
@@ -20,6 +26,6 @@ class Admin::TutorialsController < Admin::BaseController
 
   private
   def tutorial_params
-    params.require(:tutorial).permit(:tag_list)
+    params.require(:tutorial).permit(:tag_list, :title, :description)
   end
 end

--- a/app/views/tutorials/show.html.erb
+++ b/app/views/tutorials/show.html.erb
@@ -1,4 +1,7 @@
 <main class="tutorials">
+  <% if @facade.videos == [] %>
+  <h4>There are no videos for this tutorial yet.</h4>
+  <% else %>
 <h2><%= @facade.title %></h2>
 <h1 id="message"></h1>
 <div class="col col-4">
@@ -65,5 +68,5 @@
     <%= link_to "More", "#", "data-action" => "click->tutorials#showDescription", id: @facade.current_video.id, class: "show-link"%>
   </p>
 </div>
-
+<% end %>
 </main>

--- a/spec/features/admin/can_create_a_tutorial_spec.rb
+++ b/spec/features/admin/can_create_a_tutorial_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+describe 'an admin can' do
+  it 'create a tutorial' do
+    admin = create(:admin)
+    allow_any_instance_of(ApplicationController)
+      .to receive(:current_user)
+      .and_return(admin)
+
+    visit new_admin_tutorial_path
+
+    fill_in "Title", with: "Mod 0"
+    fill_in "Description", with: "Prework"
+
+    click_on 'Save'
+    latest = Tutorial.last
+
+    expect(current_path).to eq(admin_dashboard_path)
+    expect(page).to have_content("Mod 0")
+
+    click_on "Mod 0"
+
+    expect(current_path).to eq(tutorial_path(latest.id))
+    expect(page).to have_content("There are no videos for this tutorial yet.")
+  end
+end


### PR DESCRIPTION
- [x] Wrote Tests
- [x] Implemented
- [] Reviewed

# Necessary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally

## Type of change
- [] New feature
- [x] Bug Fix

# Implements/Fixes: tutorial show page errors out if the tutorial doesn't have a video
## Description of Changes:  Wrote a test to check for the error.  Had to start by writing the test for an admin to create a new tutorial.  Wrote the code in the admin/tutorial controller for the create action.  Once an admin could create a tutorial, then began to work on the bug fix.  In the tutorial show view, added logic to show a message about the tutorial not having a video, if none were present.  Adding the logic in the view was the easiest fix, as it did not require having to make large changes to the tutorial facade or the tutorial show page.

closes #8

# Check the correct boxes
- [x] This broke nothing
- [] This broke some stuff
- [] This broke everything

# Testing Changes
- [x] No Tests have been changed
- [] Some Tests have been changed
- [] All of the Tests have been changed (Please describe happened)

# Checklist:

- [] My code has no unused/commented out code
- [x] I have reviewed my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have fully tested my code

